### PR TITLE
Fixed an indexing error in correct's remove_water function.

### DIFF
--- a/PyHum/_pyhum_correct.py
+++ b/PyHum/_pyhum_correct.py
@@ -702,11 +702,11 @@ def remove_water(fp,bed,shape, dep_m, pix_m, calcR,  maxW):
 
           a = np.ones(np.shape(fp))
           for k in range(len(d)): 
-             a[:,k] = d[k]/yvec
+             a[:,[k]] = d[k]/yvec
 
           r = np.ones(np.shape(fp))
           for k in range(len(d)): 
-             r[:,k] = np.sqrt(yvec**2 - d[k]**2)
+             r[:,[k]] = np.sqrt(yvec**2 - d[k]**2)
 
           # shift proportionally depending on where the bed is
           for k in range(np.shape(r)[1]):


### PR DESCRIPTION
When running the dotest() script, I was receiving errors like this one: 

> Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/bensomt1/miniconda2/envs/pyhum/lib/python2.7/site-packages/PyHum/test.py", line 138, in dotest
    PyHum.correct(humfile, sonpath, maxW, doplot, dofilt, correct_withwater, ph, temp, salinity, dconcfile)
  File "/home/bensomt1/miniconda2/envs/pyhum/lib/python2.7/site-packages/PyHum/_pyhum_correct.py", line 314, in correct
    Zt, R, A = remove_water(star_fp, bed, shape_star, dep_m, pix_m, 1,  maxW)
  File "/home/bensomt1/miniconda2/envs/pyhum/lib/python2.7/site-packages/PyHum/_pyhum_correct.py", line 705, in remove_water
    a[:,k] = d[k]/yvec
ValueError: could not broadcast input array from shape (1479,1) into shape (1479)

on lines 705 and 709 of _pyhum_correct.py. As far as I know, this indexing change should fix these errors (at the very least, the test script now gets through this part without throwing an error - I cannot confirm whether it's a complete fix, as I'm having other issues which I'll submit an Issue for shortly).